### PR TITLE
VIH-9929 Update vm size

### DIFF
--- a/terraform/infra/_variables.tf
+++ b/terraform/infra/_variables.tf
@@ -33,7 +33,7 @@ variable "address_space" {
 
 variable "vm_size" {
   type    = string
-  default = "Standard_F8s_v2"
+  default = "D4ds_v5"
 }
 
 variable "admin_user" {

--- a/terraform/infra/_variables.tf
+++ b/terraform/infra/_variables.tf
@@ -33,7 +33,7 @@ variable "address_space" {
 
 variable "vm_size" {
   type    = string
-  default = "D4ds_v5"
+  default = "Standard_D4ds_v5"
 }
 
 variable "admin_user" {

--- a/vars/terraform/dev.tfvars
+++ b/vars/terraform/dev.tfvars
@@ -43,7 +43,7 @@ route_table = [
     next_hop_in_ip_address = null
   }
 ]
-
+dcd_cnp_subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
 wowza_lb_private_ip_address = "10.100.198.71"
 
 aks_address_space = "10.145.0.0/18"

--- a/vars/terraform/stg.tfvars
+++ b/vars/terraform/stg.tfvars
@@ -43,6 +43,8 @@ route_table = [
     next_hop_in_ip_address = "10.11.8.36"
   }
 ]
+dcd_cnp_subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+
 dynatrace_tenant = "yrk32651"
 
 wowza_lb_private_ip_address = "10.50.10.120"

--- a/vars/terraform/test.tfvars
+++ b/vars/terraform/test.tfvars
@@ -43,6 +43,7 @@ route_table = [
     next_hop_in_ip_address = null
   }
 ]
+dcd_cnp_subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
 
 wowza_lb_private_ip_address = "10.23.255.216"
 

--- a/vars/terraform/test.tfvars
+++ b/vars/terraform/test.tfvars
@@ -50,3 +50,5 @@ wowza_lb_private_ip_address = "10.23.255.216"
 aks_address_space = "10.141.0.0/18"
 
 wowza_instance_count = 2
+
+sa_default_action = "Deny"

--- a/vars/terraform/test.tfvars
+++ b/vars/terraform/test.tfvars
@@ -50,5 +50,3 @@ wowza_lb_private_ip_address = "10.23.255.216"
 aks_address_space = "10.141.0.0/18"
 
 wowza_instance_count = 2
-
-sa_default_action = "Deny"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-9929

### Change description ###

 Current vm size is Standard_F8s_v2 and needs to be updated as per the following document to `D4ds_v5`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```