### PR TITLE
VIH-9929 Update size

### DIFF
--- a/terraform/infra/_variables.tf
+++ b/terraform/infra/_variables.tf
@@ -33,7 +33,7 @@ variable "address_space" {
 
 variable "vm_size" {
   type    = string
-  default = "Standard_F8s_v2"
+  default = "Standard_D4ds_v5"
 }
 
 variable "admin_user" {

--- a/vars/terraform/dev.tfvars
+++ b/vars/terraform/dev.tfvars
@@ -48,4 +48,6 @@ wowza_lb_private_ip_address = "10.100.198.71"
 
 aks_address_space = "10.145.0.0/18"
 
+dcd_cnp_subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+
 wowza_instance_count = 1

--- a/vars/terraform/stg.tfvars
+++ b/vars/terraform/stg.tfvars
@@ -47,4 +47,6 @@ dynatrace_tenant = "yrk32651"
 
 wowza_lb_private_ip_address = "10.50.10.120"
 
+dcd_cnp_subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+
 aks_address_space = "10.148.0.0/18"

--- a/vars/terraform/test.tfvars
+++ b/vars/terraform/test.tfvars
@@ -50,4 +50,6 @@ aks_address_space = "10.141.0.0/18"
 
 wowza_instance_count = 2
 
+dcd_cnp_subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+
 sa_default_action = "Deny"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-9929

### Change description ###

Current vm size is Standard_F8s_v2 and needs to be updated as per the following document to D4ds_v5

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```