### PR TITLE
VIH-10342 Update UDR for test env

### DIFF
--- a/vars/terraform/test.tfvars
+++ b/vars/terraform/test.tfvars
@@ -29,6 +29,12 @@ route_table = [
     next_hop_in_ip_address = "10.11.8.36"
   },
   {
+    name                   = "ss_test_aks_perf_test"
+    address_prefix         = "10.24.0.112/28"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
     name                   = "azure_control_plane"
     address_prefix         = "51.145.56.125/32"
     next_hop_type          = "Internet"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[VIH-10342](https://tools.hmcts.net/jira/browse/VIH-10342)

### Change description ###

Add UDR to allow route from Wowza back to the Perf Test VMs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```