### PR TITLE
VIH-10980 bring start of vm-on schedule forward 1 hour

### DIFF
--- a/vars/terraform/stg.tfvars
+++ b/vars/terraform/stg.tfvars
@@ -10,7 +10,7 @@ schedules = [
     name      = "vm-on",
     frequency = "Week"
     interval  = 1
-    run_time  = "08:00:00"
+    run_time  = "07:00:00"
     start_vm  = true
     week_days = ["Monday","Tuesday","Wednesday","Thursday","Friday"]
   },

--- a/vars/terraform/test.tfvars
+++ b/vars/terraform/test.tfvars
@@ -9,7 +9,7 @@ schedules = [
     name      = "vm-on",
     frequency = "Week"
     interval  = 1
-    run_time  = "08:00:00"
+    run_time  = "07:00:00"
     start_vm  = true
     week_days = ["Monday","Tuesday","Wednesday","Thursday","Friday"]
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-10981


### Change description ###
The previous start time of the VM-ON schedule for Test & Stg was 0800, which in BST, meant 0900, which was too late. This change brings it forward by 1 hour.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```