### PR TITLE
VIH-11403 adding in route table for envs to direct from internet to palo

### DIFF
--- a/vars/terraform/demo.tfvars
+++ b/vars/terraform/demo.tfvars
@@ -33,6 +33,12 @@ route_table = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
     name                   = "azure_control_plane"
     address_prefix         = "51.145.56.125/32"
     next_hop_type          = "Internet"

--- a/vars/terraform/dev.tfvars
+++ b/vars/terraform/dev.tfvars
@@ -32,6 +32,12 @@ route_table = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
     name                   = "ss_stg_aks"
     address_prefix         = "10.148.0.0/18"
     next_hop_type          = "VirtualAppliance"

--- a/vars/terraform/ithc.tfvars
+++ b/vars/terraform/ithc.tfvars
@@ -23,6 +23,12 @@ route_table = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
     name                   = "ss_stg_aks"
     address_prefix         = "10.148.0.0/18"
     next_hop_type          = "VirtualAppliance"

--- a/vars/terraform/prod.tfvars
+++ b/vars/terraform/prod.tfvars
@@ -21,6 +21,12 @@ route_table = [
     next_hop_in_ip_address = null
   },
   {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
     name                   = "ss_prod_aks"
     address_prefix         = "10.144.0.0/18"
     next_hop_type          = "VirtualAppliance"

--- a/vars/terraform/sbox.tfvars
+++ b/vars/terraform/sbox.tfvars
@@ -20,6 +20,12 @@ route_table = [
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.10.200.36"
   },
+    {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.10.200.36"
+  },
   {
     name                   = "azure_control_plane"
     address_prefix         = "51.145.56.125/32"

--- a/vars/terraform/sbox.tfvars
+++ b/vars/terraform/sbox.tfvars
@@ -20,7 +20,7 @@ route_table = [
     next_hop_type          = "VirtualAppliance"
     next_hop_in_ip_address = "10.10.200.36"
   },
-    {
+  {
     name                   = "default"
     address_prefix         = "0.0.0.0/0"
     next_hop_type          = "VirtualAppliance"

--- a/vars/terraform/stg.tfvars
+++ b/vars/terraform/stg.tfvars
@@ -32,6 +32,12 @@ route_table = [
     next_hop_in_ip_address = null
   },
   {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.8.36"
+  },
+  {
     name                   = "ss_stg_aks"
     address_prefix         = "10.148.0.0/18"
     next_hop_type          = "VirtualAppliance"

--- a/vars/terraform/test.tfvars
+++ b/vars/terraform/test.tfvars
@@ -31,6 +31,12 @@ route_table = [
     next_hop_in_ip_address = "10.11.72.36"
   },
   {
+    name                   = "default"
+    address_prefix         = "0.0.0.0/0"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
     name                   = "ss_stg_aks"
     address_prefix         = "10.148.0.0/18"
     next_hop_type          = "VirtualAppliance"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-11403

### Change description ###

Add in the route that routes it form the internet 0.0.0.0/0 to the virtual applianece. View each env and map it to corresponding palo hub.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```