### PR TITLE
VIH-11410 Fix for prod service connection not able to access non-prod sub

### DIFF
--- a/terraform/infra/_providers.tf
+++ b/terraform/infra/_providers.tf
@@ -94,4 +94,5 @@ provider "azurerm" {
   features {}
   alias           = "dts-management-nonprod-intsvc"
   subscription_id = "b44eb479-9ae2-42e7-9c63-f3c599719b6f" # DTS-MANAGEMENT-NONPROD-INTSVC
+  skip_provider_registration = true
 }

--- a/terraform/infra/_providers.tf
+++ b/terraform/infra/_providers.tf
@@ -92,7 +92,7 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
-  alias                      = "dts-management-nonprod-intsvc"
-  subscription_id            = "b44eb479-9ae2-42e7-9c63-f3c599719b6f" # DTS-MANAGEMENT-NONPROD-INTSVC
-  skip_provider_registration = true
+  alias                           = "dts-management-nonprod-intsvc"
+  subscription_id                 = "b44eb479-9ae2-42e7-9c63-f3c599719b6f" # DTS-MANAGEMENT-NONPROD-INTSVC
+  resource_provider_registrations = "none"
 }

--- a/terraform/infra/_providers.tf
+++ b/terraform/infra/_providers.tf
@@ -90,9 +90,10 @@ provider "azurerm" {
   subscription_id = "1c4f0704-a29e-403d-b719-b90c34ef14c9" # dcd-cnp-DEV
 }
 
+# DTS-MANAGEMENT-NONPROD-INTSVC/DTS-MANAGEMENT-PROD-INTSVC
 provider "azurerm" {
   features {}
   alias                           = "dts-management-nonprod-intsvc"
-  subscription_id                 = "b44eb479-9ae2-42e7-9c63-f3c599719b6f" # DTS-MANAGEMENT-NONPROD-INTSVC
+  subscription_id                 = var.environment == "prod" ? "2b1afc19-5ca9-4796-a56f-574a58670244" : "b44eb479-9ae2-42e7-9c63-f3c599719b6f"
   resource_provider_registrations = "none"
 }

--- a/terraform/infra/_providers.tf
+++ b/terraform/infra/_providers.tf
@@ -92,7 +92,7 @@ provider "azurerm" {
 
 provider "azurerm" {
   features {}
-  alias           = "dts-management-nonprod-intsvc"
-  subscription_id = "b44eb479-9ae2-42e7-9c63-f3c599719b6f" # DTS-MANAGEMENT-NONPROD-INTSVC
+  alias                      = "dts-management-nonprod-intsvc"
+  subscription_id            = "b44eb479-9ae2-42e7-9c63-f3c599719b6f" # DTS-MANAGEMENT-NONPROD-INTSVC
   skip_provider_registration = true
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-11410


### Change description ###
Add expression to azurerm provider alias to use prod dynatrace sub only when running prod env
